### PR TITLE
Fixed method abortIf async boolean & Added runnable interface, called when task is aborted

### DIFF
--- a/core/src/main/java/eu/okaeri/tasker/core/chain/TaskerChain.java
+++ b/core/src/main/java/eu/okaeri/tasker/core/chain/TaskerChain.java
@@ -93,7 +93,7 @@ public class TaskerChain<T> {
                 this.abort.set(true);
             }
         };
-        return this.lastAsync.get() ? this.async(runnable) : this.sync(runnable);
+        return async ? this.async(runnable) : this.sync(runnable);
     }
 
     public TaskerChain<T> abortIfSync(@NonNull Predicate<T> predicate) {


### PR DESCRIPTION
Instead of doing:
```java
        this.tasker.newChain()
                .abortIf(() -> {
                    if (!(sender instanceof Player)) {
                        this.send(this.messageConfig.notPlayer, sender);
                        return true;
                    }
                    return false;
                })
                .execute();
```
We can do:
```java
        this.tasker.newChain()
                .abortIf(() -> !(sender instanceof Player),
                        () -> this.send(this.messageConfig.notPlayer, sender))
                .execute();
```